### PR TITLE
Update 2018-12-25-darktable-2.6.md

### DIFF
--- a/content/blog/2018-12-25-darktable-2.6/2018-12-25-darktable-2.6.md
+++ b/content/blog/2018-12-25-darktable-2.6/2018-12-25-darktable-2.6.md
@@ -632,7 +632,7 @@ base curve disabled:
 
 The snow is obviously white in the real scene, but the snow exposed to
 the sun reflects the sun's light, while the one in the shadow reflects
-the sky's light, much bluer. The color picker module in the right
+the sky's light, much bluer. The color picker module in the left
 sidebar of the darkroom allows visualizing and quantifying these color
 casts:
 


### PR DESCRIPTION
color picker is on the left sidebar of the darkroom, not on the right one.